### PR TITLE
Fixed Upper Mass Limit to 8

### DIFF
--- a/starwave/starwave.py
+++ b/starwave/starwave.py
@@ -159,17 +159,17 @@ class StarWave:
 
         if mass_range is None or len(mass_range) != 2 or mass_range[0] < iso_mass_min or mass_range[1] > default_upper_mass or mass_range[0] >= mass_range[1]:
             self.mass_range = (iso_mass_min, default_upper_mass)
-            print('mass range not provided or invalid, using mass range: %.2f - %.2f' % (iso_mass_min, default_upper_mass))
+            print('mass range not provided or invalid, using mass range: %.2f - %.2f Msun' % (iso_mass_min, default_upper_mass))
         else:
             self.mass_range = mass_range
-            print('using provided mass range: %.2f - %.2f' % (mass_range[0], mass_range[1]))
+            print('using provided mass range: %.2f - %.2f Msun' % (mass_range[0], mass_range[1]))
 
         if age_range is None or len(age_range) != 2 or age_range[0] < iso_age_min or age_range[1] > iso_age_max or age_range[0] >= age_range[1]:
             self.age_range = (iso_age_min, iso_age_max)
-            print('age range not provided or invalid, using full isochrone age range: %.2f - %.2f' % (iso_age_min, iso_age_max))
+            print('age range not provided or invalid, using full isochrone age range: %.2f - %.2f Gyr' % (iso_age_min, iso_age_max))
         else:
             self.age_range = age_range
-            print('using provided age range: %.2f - %.2f' % (age_range[0], age_range[1]))
+            print('using provided age range: %.2f - %.2f Gyr' % (age_range[0], age_range[1]))
 
         if feh_range is None or len(feh_range) != 2 or feh_range[0] < iso_feh_min or feh_range[1] > iso_feh_max or feh_range[0] >= feh_range[1]:
             self.feh_range = (iso_feh_min, iso_feh_max)

--- a/starwave/starwave.py
+++ b/starwave/starwave.py
@@ -79,7 +79,7 @@ class StarWave:
             TRGB value to use for the CMD fitting, default is -100 (no TRGB)
         mass_range : tuple
             tuple of (min_mass, max_mass) to limit the mass range of the sampled stars
-            if not provided, defaults to the full range of the isochrone data
+            if None or invalid, defaults to the range of the isochrone lower limit to 8 Msun (for binary systems)
         age_range : tuple
             tuple of (min_age, max_age) to limit the age range of the sampled stars
             if not provided, defaults to the full range of the isochrone data
@@ -138,7 +138,7 @@ class StarWave:
             Multi-indexed dataframe containing isochrone data for the required photometric bands.
         mass_range : tuple or None
             tuple of (min_mass, max_mass) to limit the mass range of the sampled stars
-            if None or invalid, defaults to the full range of the isochrone data
+            if None or invalid, defaults to the range of the isochrone lower limit to 8 Msun
         age_range : tuple or None
             tuple of (min_age, max_age) to limit the age range of the sampled stars
             if None or invalid, defaults to the full range of the isochrone data
@@ -159,7 +159,7 @@ class StarWave:
 
         if mass_range is None or len(mass_range) != 2 or mass_range[0] < iso_mass_min or mass_range[1] > default_upper_mass or mass_range[0] >= mass_range[1]:
             self.mass_range = (iso_mass_min, default_upper_mass)
-            print('mass range not provided or invalid, using full isochrone mass range: %.2f - %.2f' % (iso_mass_min, default_upper_mass))
+            print('mass range not provided or invalid, using mass range: %.2f - %.2f' % (iso_mass_min, default_upper_mass))
         else:
             self.mass_range = mass_range
             print('using provided mass range: %.2f - %.2f' % (mass_range[0], mass_range[1]))

--- a/starwave/starwave.py
+++ b/starwave/starwave.py
@@ -44,7 +44,7 @@ class StarWave:
     """
 
     def __init__(self, isodf, asdf, bands, band_lambdas, imf_type, sfh_type = 'gaussian',
-        dm_type = 'gaussian', av_type = 'lognormal', sfh_grid = None, Rv = 3.1, trgb=-100, l_mass=None, age_range=None, feh_range=None, params_kwargs = None):
+        dm_type = 'gaussian', av_type = 'lognormal', sfh_grid = None, Rv = 3.1, trgb=-100, mass_range=None, age_range=None, feh_range=None, params_kwargs = None):
         """
         Initializes the StarWave object
         Parameters
@@ -77,8 +77,9 @@ class StarWave:
             Rv value to use for the extinction law, default is 3.1
         trgb : float
             TRGB value to use for the CMD fitting, default is -100 (no TRGB)
-        l_mass : float
-            lower limit of the mass range to sample from, if not provided, defaults to isochrone data lower limit
+        mass_range : tuple
+            tuple of (min_mass, max_mass) to limit the mass range of the sampled stars
+            if not provided, defaults to the full range of the isochrone data
         age_range : tuple
             tuple of (min_age, max_age) to limit the age range of the sampled stars
             if not provided, defaults to the full range of the isochrone data
@@ -119,7 +120,7 @@ class StarWave:
         self.Rv = Rv
         self.band_lambdas = band_lambdas
 
-        self.set_param_range(isodf, l_mass, age_range, feh_range)
+        self.set_param_range(isodf, mass_range, age_range, feh_range)
 
         self.debug = False
         
@@ -127,17 +128,17 @@ class StarWave:
         print('using Rv = %.1f' % (self.Rv))
         self.params.summary()
 
-    def set_param_range(self, isodf, l_mass, age_range, feh_range):
+    def set_param_range(self, isodf, mass_range, age_range, feh_range):
         """
         Set the mass, age, and metallicity ranges based on the isochrone dataframe.
         If the provided ranges are invalid, use the full range from the isochrone dataframe.
-        The mass upper limit is always set to be 8 to account to binary systems.
         Parameters
         ----------
         isodf : pandas DataFrame
             Multi-indexed dataframe containing isochrone data for the required photometric bands.
-        l_mass : float
-            lower limit of the mass range to sample from, if not provided, defaults to isochrone data lower limit
+        mass_range : tuple or None
+            tuple of (min_mass, max_mass) to limit the mass range of the sampled stars
+            if None or invalid, defaults to the full range of the isochrone data
         age_range : tuple or None
             tuple of (min_age, max_age) to limit the age range of the sampled stars
             if None or invalid, defaults to the full range of the isochrone data
@@ -153,14 +154,15 @@ class StarWave:
         iso_feh_max = iso_feh.max()
         iso_masses = isodf.index.get_level_values('mass').unique()
         iso_mass_min = iso_masses.min()
-        iso_mass_max = iso_masses.max()
+        # iso_mass_max = iso_masses.max()
+        default_upper_mass = 8.0
 
-        if l_mass is None  or l_mass < iso_mass_min  or l_mass >= 8:
-            self.mass_range = (iso_mass_min, 8)
-            print('mass range not provided or invalid, using full isochrone mass range: %.2f - 8.0' % (iso_mass_min))
+        if mass_range is None or len(mass_range) != 2 or mass_range[0] < iso_mass_min or mass_range[1] > default_upper_mass or mass_range[0] >= mass_range[1]:
+            self.mass_range = (iso_mass_min, default_upper_mass)
+            print('mass range not provided or invalid, using full isochrone mass range: %.2f - %.2f' % (iso_mass_min, default_upper_mass))
         else:
-            self.mass_range = (l_mass, 8)
-            print('using provided mass range: %.2f - 8.0' % (l_mass))
+            self.mass_range = mass_range
+            print('using provided mass range: %.2f - %.2f' % (mass_range[0], mass_range[1]))
 
         if age_range is None or len(age_range) != 2 or age_range[0] < iso_age_min or age_range[1] > iso_age_max or age_range[0] >= age_range[1]:
             self.age_range = (iso_age_min, iso_age_max)


### PR DESCRIPTION
The starwave class takes in a float l_mass to determine the lower mass limit to be sampled, while fixing the upper limit to 8 solar masses to account for binary systems.